### PR TITLE
Refine RTL layout for Persian page

### DIFF
--- a/fa.html
+++ b/fa.html
@@ -58,21 +58,21 @@
 
         <header class="fixed inset-x-0 top-0 z-50 border-b border-white/10 bg-slate-950/70 backdrop-blur-xl">
             <nav class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 lg:px-8">
-                <a href="#home" class="flex items-center space-x-3" x-bind:class="isFa() ? 'space-x-reverse' : ''">
+                <a href="#home" class="flex items-center gap-3">
                     <img src="/static/logo.svg" alt="Shahin Developer logo" class="h-12 w-12">
                     <div x-bind:class="isFa() ? 'text-right' : ''">
                         <span class="block text-[11px] text-white/60" x-bind:class="isFa() ? '' : 'uppercase tracking-[0.35em]'" x-text="isFa() ? copy.footer.brandTag.fa : copy.footer.brandTag.en"></span>
                         <span class="block text-lg font-semibold text-white" x-text="isFa() ? copy.footer.brandSubtitle.fa : copy.footer.brandSubtitle.en"></span>
                     </div>
                 </a>
-                <div class="hidden items-center space-x-10 text-sm font-medium text-white/70 lg:flex" x-bind:class="isFa() ? 'flex-row-reverse space-x-reverse' : ''">
+                <div class="hidden items-center gap-10 text-sm font-medium text-white/70 lg:flex">
                     <a href="#services" class="transition hover:text-white" x-text="copy.nav.services[lang]"></a>
                     <a href="#projects" class="transition hover:text-white" x-text="copy.nav.projects[lang]"></a>
                     <a href="#process" class="transition hover:text-white" x-text="copy.nav.process[lang]"></a>
                     <a href="#testimonials" class="transition hover:text-white" x-text="copy.nav.testimonials[lang]"></a>
                     <a href="#contact" class="transition hover:text-white" x-text="copy.nav.contact[lang]"></a>
                 </div>
-                <div class="hidden items-center gap-3 lg:flex" x-bind:class="isFa() ? 'flex-row-reverse' : ''">
+                <div class="hidden items-center gap-3 lg:flex">
                     <div class="flex items-center rounded-full border border-white/20 bg-white/5 p-1 text-xs font-semibold">
                         <button @click="setLang('en')" class="rounded-full px-3 py-1 transition" x-bind:class="lang === 'en' ? 'bg-white text-slate-950 shadow' : 'text-white/70 hover:text-white'">EN</button>
                         <button @click="setLang('fa')" class="rounded-full px-3 py-1 transition" x-bind:class="lang === 'fa' ? 'bg-white text-slate-950 shadow' : 'text-white/70 hover:text-white'">فا</button>
@@ -117,7 +117,7 @@
                             <span x-text="copy.hero.headlinePrimary[lang]"></span>
                             <span class="block bg-gradient-to-r from-brand-300 via-cyan-200 to-emerald-200 bg-clip-text text-transparent" x-text="copy.hero.headlineAccent[lang]"></span>
                         </h1>
-                        <p class="max-w-xl text-lg text-white/70" x-bind:class="isFa() ? 'ml-auto leading-relaxed' : ''" x-text="copy.hero.blurb[lang]"></p>
+                        <p class="max-w-xl text-lg leading-relaxed text-white/70" x-text="copy.hero.blurb[lang]"></p>
                         <div class="flex flex-wrap items-center gap-4" x-bind:class="isFa() ? 'justify-end flex-row-reverse' : ''">
                             <a href="#projects" class="rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-xl shadow-brand-500/30 transition hover:-translate-y-0.5 hover:shadow-brand-400/40" x-text="copy.hero.primaryCta[lang]"></a>
                             <a href="mailto:info@shahindev.com" class="rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-brand-300/60 hover:text-white" x-text="copy.hero.secondaryCta[lang]"></a>
@@ -159,14 +159,14 @@
 
             <section id="services" class="relative border-t border-white/10 bg-slate-950/90 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
-                    <div class="mx-auto max-w-3xl space-y-4 text-center" x-bind:class="isFa() ? 'text-right lg:text-right lg:ml-auto lg:mr-0' : ''">
+                    <div class="mx-auto max-w-3xl space-y-4" x-bind:class="isFa() ? 'text-right lg:text-right' : 'text-center lg:text-left'">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold text-brand-200" x-bind:class="isFa() ? 'tracking-normal' : 'uppercase tracking-[0.35em]'" x-text="copy.services.tag[lang]"></span>
                         <h2 class="text-3xl font-semibold text-white sm:text-4xl" x-text="copy.services.title[lang]"></h2>
                         <p class="text-base text-white/60" x-text="copy.services.blurb[lang]"></p>
                     </div>
                     <div class="mt-16 grid gap-10 md:grid-cols-2 xl:grid-cols-3">
-                        <div class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.05] p-8 shadow-lg shadow-black/40 transition hover:-translate-y-1 hover:border-brand-400/40" x-bind:class="isFa() ? 'text-right' : ''">
-                            <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-brand-500/20 to-cyan-400/30 text-brand-200" x-bind:class="isFa() ? 'ml-auto' : ''">
+                        <div class="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-white/[0.05] p-8 shadow-lg shadow-black/40 transition hover:-translate-y-1 hover:border-brand-400/40" x-bind:class="isFa() ? 'items-end text-right' : ''">
+                            <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-brand-500/20 to-cyan-400/30 text-brand-200">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75v-3a3.75 3.75 0 117.5 0v3M6 9.75h15M4.5 12.75h15M3 15.75h15M3 18.75h12" />
                                 </svg>
@@ -179,8 +179,8 @@
                                 </template>
                             </ul>
                         </div>
-                        <div class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.05] p-8 shadow-lg shadow-black/40 transition hover:-translate-y-1 hover:border-brand-400/40" x-bind:class="isFa() ? 'text-right' : ''">
-                            <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-brand-500/20 to-cyan-400/30 text-brand-200" x-bind:class="isFa() ? 'ml-auto' : ''">
+                        <div class="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-white/[0.05] p-8 shadow-lg shadow-black/40 transition hover:-translate-y-1 hover:border-brand-400/40" x-bind:class="isFa() ? 'items-end text-right' : ''">
+                            <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-brand-500/20 to-cyan-400/30 text-brand-200">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 3.75h15l-1.5 4.5h-12l-1.5-4.5zM3 8.25h18M4.5 12.75h15M6 17.25h12" />
                                 </svg>
@@ -193,8 +193,8 @@
                                 </template>
                             </ul>
                         </div>
-                        <div class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.05] p-8 shadow-lg shadow-black/40 transition hover:-translate-y-1 hover:border-brand-400/40" x-bind:class="isFa() ? 'text-right' : ''">
-                            <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-brand-500/20 to-cyan-400/30 text-brand-200" x-bind:class="isFa() ? 'ml-auto' : ''">
+                        <div class="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-white/[0.05] p-8 shadow-lg shadow-black/40 transition hover:-translate-y-1 hover:border-brand-400/40" x-bind:class="isFa() ? 'items-end text-right' : ''">
+                            <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-brand-500/20 to-cyan-400/30 text-brand-200">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 3.75h6M12 3.75v12m-6 4.5h12" />
                                 </svg>
@@ -287,7 +287,7 @@
 
             <section id="process" class="relative border-t border-white/10 bg-slate-950/95 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
-                    <div class="mx-auto max-w-3xl space-y-4 text-center" x-bind:class="isFa() ? 'text-right lg:text-right lg:ml-auto lg:mr-0' : ''">
+                    <div class="mx-auto max-w-3xl space-y-4" x-bind:class="isFa() ? 'text-right lg:text-right' : 'text-center lg:text-left'">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold text-brand-200" x-bind:class="isFa() ? 'tracking-normal' : 'uppercase tracking-[0.35em]'" x-text="copy.process.tag[lang]"></span>
                         <h2 class="text-3xl font-semibold text-white sm:text-4xl" x-text="copy.process.title[lang]"></h2>
                         <p class="text-base text-white/60" x-text="copy.process.blurb[lang]"></p>
@@ -312,7 +312,7 @@
             </section>
             <section id="testimonials" class="relative border-t border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
-                    <div class="mx-auto max-w-3xl space-y-4 text-center" x-bind:class="isFa() ? 'text-right lg:text-right lg:ml-auto lg:mr-0' : ''">
+                    <div class="mx-auto max-w-3xl space-y-4" x-bind:class="isFa() ? 'text-right lg:text-right' : 'text-center lg:text-left'">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold text-brand-200" x-bind:class="isFa() ? 'tracking-normal' : 'uppercase tracking-[0.35em]'" x-text="copy.testimonials.tag[lang]"></span>
                         <h2 class="text-3xl font-semibold text-white sm:text-4xl" x-text="copy.testimonials.title[lang]"></h2>
                         <p class="text-base text-white/60" x-text="copy.testimonials.blurb[lang]"></p>
@@ -359,7 +359,7 @@
                                             <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5h7.5a2.25 2.25 0 012.25 2.25v10.5A2.25 2.25 0 0115.75 19.5h-7.5A2.25 2.25 0 016 17.25V6.75A2.25 2.25 0 018.25 4.5z" />
                                         </svg>
                                     </span>
-                                    <div class="space-x-3" x-bind:class="isFa() ? 'space-x-reverse text-right' : ''">
+                                    <div class="flex items-center gap-3" x-bind:class="isFa() ? 'justify-end text-right' : ''">
                                         <a href="https://twitter.com/shahin_g_rostami" target="_blank" class="text-white/70 transition hover:text-brand-200" x-text="copy.contact.socials.twitter[lang]"></a>
                                         <span class="text-white/20">/</span>
                                         <a href="https://instagram.com/shahin_g_rostami" target="_blank" class="text-white/70 transition hover:text-brand-200" x-text="copy.contact.socials.instagram[lang]"></a>
@@ -393,7 +393,7 @@
         <footer class="border-t border-white/10 bg-slate-950/95 py-12">
             <div class="mx-auto flex max-w-6xl flex-col gap-10 px-6 lg:flex-row lg:justify-between lg:px-8" x-bind:class="isFa() ? 'lg:flex-row-reverse' : ''">
                 <div class="max-w-sm space-y-4" x-bind:class="isFa() ? 'text-right' : ''">
-                    <a href="#home" class="flex items-center space-x-3" x-bind:class="isFa() ? 'space-x-reverse' : ''">
+                    <a href="#home" class="flex items-center gap-3">
                         <img src="/static/logo.svg" alt="Shahin Developer logo" class="h-10 w-10">
                         <div>
                             <span class="block text-xs text-white/50" x-bind:class="isFa() ? '' : 'uppercase tracking-[0.35em]'" x-text="isFa() ? copy.footer.brandTag.fa : copy.footer.brandTag.en"></span>


### PR DESCRIPTION
## Summary
- replace direction-reversing spacing classes with neutral flex `gap` usage to avoid inverted navigation order
- simplify headline and section alignment bindings so Persian copy renders right-aligned without conflicting center styles
- refactor service cards to flex-column blocks that naturally right-align icons and content for RTL readability

## Testing
- no automated tests; static site

------
https://chatgpt.com/codex/tasks/task_e_68d3e3150440832d8dd34ef14a14c297