### PR TITLE
Improve mobile navigation and spacing

### DIFF
--- a/en.html
+++ b/en.html
@@ -53,27 +53,57 @@
         </div>
 
         <header class="fixed inset-x-0 top-0 z-50 border-b border-white/10 bg-slate-950/70 backdrop-blur-xl">
-            <nav class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4 lg:px-8">
-                <a href="#home" class="flex items-center gap-3">
-                    <img src="/static/logo.svg" alt="Shahin Developer logo" class="h-12 w-12">
-                    <div>
-                        <span class="block text-[11px] text-white/60 uppercase tracking-[0.35em]">Shahin Developer</span>
-                        <span class="block text-lg font-semibold text-white">Digital Product Studio</span>
-                    </div>
-                </a>
-                <div class="flex flex-1 flex-wrap items-center justify-end gap-6 text-sm font-medium text-white/70">
+            <nav class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4 lg:flex-nowrap lg:px-8">
+                <div class="flex w-full items-center justify-between gap-4 lg:w-auto lg:flex-none">
+                    <a href="#home" class="flex items-center gap-3">
+                        <img src="/static/logo.svg" alt="Shahin Developer logo" class="h-12 w-12">
+                        <div>
+                            <span class="block text-[11px] text-white/60 uppercase tracking-[0.35em]">Shahin Developer</span>
+                            <span class="block text-lg font-semibold text-white">Digital Product Studio</span>
+                        </div>
+                    </a>
+                    <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center rounded-xl border border-white/15 bg-white/5 p-2 text-white/70 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-300 lg:hidden" aria-expanded="false" aria-controls="mobile-menu">
+                        <span class="sr-only">Open navigation</span>
+                        <svg data-menu-icon="open" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                        <svg data-menu-icon="close" xmlns="http://www.w3.org/2000/svg" class="hidden h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M6 18L18 6" />
+                        </svg>
+                    </button>
+                </div>
+                <div class="hidden flex-1 items-center justify-end gap-6 text-sm font-medium text-white/70 lg:flex">
                     <a href="#services" class="transition hover:text-white">Services</a>
                     <a href="#projects" class="transition hover:text-white">Projects</a>
                     <a href="#process" class="transition hover:text-white">Process</a>
                     <a href="#testimonials" class="transition hover:text-white">Testimonials</a>
                     <a href="#contact" class="transition hover:text-white">Contact</a>
                 </div>
-                <div class="flex flex-wrap items-center gap-3">
+                <div class="hidden items-center gap-3 lg:flex">
                     <div class="flex items-center rounded-full border border-white/20 bg-white/5 p-1 text-xs font-semibold">
                         <a href="en.html" class="rounded-full px-3 py-1 transition bg-white text-slate-950 shadow">EN</a>
                         <a href="fa.html" class="rounded-full px-3 py-1 transition text-white/70 hover:text-white">FA</a>
                     </div>
                     <a href="#contact" class="rounded-full bg-gradient-to-r from-brand-500 to-cyan-400 px-5 py-2 text-sm font-semibold text-slate-950 shadow-glow transition hover:-translate-y-0.5 hover:shadow-xl">Let's talk</a>
+                </div>
+                <div id="mobile-menu" class="hidden w-full space-y-4 border-t border-white/10 pt-4 text-left text-sm font-medium text-white/70 lg:hidden">
+                    <div class="flex flex-col gap-3">
+                        <a href="#services" class="transition hover:text-white">Services</a>
+                        <a href="#projects" class="transition hover:text-white">Projects</a>
+                        <a href="#process" class="transition hover:text-white">Process</a>
+                        <a href="#testimonials" class="transition hover:text-white">Testimonials</a>
+                        <a href="#contact" class="transition hover:text-white">Contact</a>
+                    </div>
+                    <div class="h-px bg-white/10"></div>
+                    <div class="flex flex-col gap-3 text-sm font-semibold text-white/80">
+                        <div class="flex justify-start">
+                            <div class="flex items-center rounded-full border border-white/20 bg-white/5 p-1 text-xs">
+                                <a href="en.html" class="rounded-full px-3 py-1 transition bg-white text-slate-950 shadow">EN</a>
+                                <a href="fa.html" class="rounded-full px-3 py-1 transition text-white/70 hover:text-white">FA</a>
+                            </div>
+                        </div>
+                        <a href="#contact" class="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-brand-500 to-cyan-400 px-5 py-2 text-sm text-slate-950 shadow-glow transition hover:-translate-y-0.5 hover:shadow-xl">Let's talk</a>
+                    </div>
                 </div>
             </nav>
         </header>
@@ -94,7 +124,7 @@
                             <a href="#projects" class="rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-xl shadow-brand-500/30 transition hover:-translate-y-0.5 hover:shadow-brand-400/40">Explore projects</a>
                             <a href="mailto:info@shahindev.com" class="rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-brand-300/60 hover:text-white">Schedule a call</a>
                         </div>
-                        <div class="grid grid-cols-2 gap-6 pt-8 text-sm text-white/70 sm:grid-cols-4">
+                        <div class="grid grid-cols-1 gap-6 pt-8 text-sm text-white/70 sm:grid-cols-2 lg:grid-cols-4">
                             <div>
                                 <p class="text-3xl font-semibold text-white">8+</p>
                                 <p>Years shipping UI</p>
@@ -137,7 +167,7 @@
                         <div class="absolute -bottom-8 hidden h-24 w-24 rounded-full bg-gradient-to-br from-emerald-400/30 to-brand-500/30 blur-xl sm:block -right-6"></div>
                     </div>
                 </div>
-            </section>            <section id="services" class="relative border-t border-white/10 bg-slate-950/90 py-24">
+            </section>            <section id="services" class="relative scroll-mt-24 border-t border-white/10 bg-slate-950/90 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="mx-auto max-w-3xl space-y-4 text-center lg:text-left">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-brand-200">Services</span>
@@ -189,7 +219,7 @@
                         </div>
                     </div>
                 </div>
-            </section>            <section id="projects" class="relative border-t border-white/10 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 py-24">
+            </section>            <section id="projects" class="relative scroll-mt-24 border-t border-white/10 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
                         <div class="max-w-2xl space-y-4">
@@ -263,7 +293,7 @@
                         </div>
                     </div>
                 </div>
-            </section>            <section id="process" class="relative border-t border-white/10 bg-slate-950/95 py-24">
+            </section>            <section id="process" class="relative scroll-mt-24 border-t border-white/10 bg-slate-950/95 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="mx-auto max-w-3xl space-y-4 text-center lg:text-left">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-brand-200">Process</span>
@@ -309,7 +339,7 @@
                         </div>
                     </div>
                 </div>
-            </section>            <section id="testimonials" class="relative border-t border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-24">
+            </section>            <section id="testimonials" class="relative scroll-mt-24 border-t border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="mx-auto max-w-3xl space-y-4 text-center lg:text-left">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-brand-200">Testimonials</span>
@@ -339,7 +369,7 @@
                         </article>
                     </div>
                 </div>
-            </section>            <section id="contact" class="relative border-t border-white/10 bg-slate-950/95 py-24">
+            </section>            <section id="contact" class="relative scroll-mt-24 border-t border-white/10 bg-slate-950/95 py-24">
                 <div class="absolute inset-x-0 -top-20 -z-10 flex justify-center blur-3xl">
                     <div class="h-64 w-[36rem] bg-gradient-to-br from-brand-500/30 via-cyan-400/20 to-emerald-300/20 opacity-70"></div>
                 </div>
@@ -439,6 +469,57 @@
                 </p>
             </div>
         </footer>
+
+        <script>
+            (function () {
+                const button = document.getElementById('mobile-menu-button');
+                const menu = document.getElementById('mobile-menu');
+                if (!button || !menu) return;
+                const icons = {
+                    open: button.querySelector('[data-menu-icon="open"]'),
+                    close: button.querySelector('[data-menu-icon="close"]'),
+                };
+                const setIcons = (isOpen) => {
+                    if (!icons.open || !icons.close) return;
+                    if (isOpen) {
+                        icons.open.classList.add('hidden');
+                        icons.close.classList.remove('hidden');
+                    } else {
+                        icons.open.classList.remove('hidden');
+                        icons.close.classList.add('hidden');
+                    }
+                };
+                const toggle = () => {
+                    const isOpen = button.getAttribute('aria-expanded') === 'true';
+                    const nextState = !isOpen;
+                    button.setAttribute('aria-expanded', String(nextState));
+                    menu.classList.toggle('hidden', !nextState);
+                    setIcons(nextState);
+                };
+                setIcons(false);
+                button.addEventListener('click', toggle);
+                menu.querySelectorAll('a').forEach((link) => {
+                    link.addEventListener('click', () => {
+                        if (button.getAttribute('aria-expanded') === 'true') {
+                            toggle();
+                        }
+                    });
+                });
+                const mediaQuery = window.matchMedia('(min-width: 1024px)');
+                const handleChange = (event) => {
+                    if (event.matches) {
+                        button.setAttribute('aria-expanded', 'false');
+                        menu.classList.add('hidden');
+                        setIcons(false);
+                    }
+                };
+                if (mediaQuery.addEventListener) {
+                    mediaQuery.addEventListener('change', handleChange);
+                } else if (mediaQuery.addListener) {
+                    mediaQuery.addListener(handleChange);
+                }
+            })();
+        </script>
     </div>
 </body>
 </html>

--- a/fa.html
+++ b/fa.html
@@ -53,27 +53,57 @@
         </div>
 
         <header class="fixed inset-x-0 top-0 z-50 border-b border-white/10 bg-slate-950/70 backdrop-blur-xl">
-            <nav class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4 lg:px-8">
-                <a href="#home" class="flex items-center gap-3">
-                    <img src="/static/logo.svg" alt="لوگوی شاهین دولوپر" class="h-12 w-12">
-                    <div class="text-right">
-                        <span class="block text-[11px] text-white/60">شاهین دولوپر</span>
-                        <span class="block text-lg font-semibold text-white">استودیوی محصولات دیجیتال</span>
-                    </div>
-                </a>
-                <div class="flex flex-1 flex-wrap items-center justify-end gap-6 text-sm font-medium text-white/70">
+            <nav class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4 lg:flex-nowrap lg:px-8">
+                <div class="flex w-full flex-row-reverse items-center justify-between gap-4 lg:w-auto lg:flex-none">
+                    <a href="#home" class="flex flex-row-reverse items-center gap-3">
+                        <img src="/static/logo.svg" alt="لوگوی شاهین دولوپر" class="h-12 w-12">
+                        <div class="text-right">
+                            <span class="block text-[11px] text-white/60">شاهین دولوپر</span>
+                            <span class="block text-lg font-semibold text-white">استودیوی محصولات دیجیتال</span>
+                        </div>
+                    </a>
+                    <button type="button" id="mobile-menu-button" class="inline-flex items-center justify-center rounded-xl border border-white/15 bg-white/5 p-2 text-white/70 transition hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-300 lg:hidden" aria-expanded="false" aria-controls="mobile-menu">
+                        <span class="sr-only">باز کردن منو</span>
+                        <svg data-menu-icon="open" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                        <svg data-menu-icon="close" xmlns="http://www.w3.org/2000/svg" class="hidden h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M6 18L18 6" />
+                        </svg>
+                    </button>
+                </div>
+                <div class="hidden flex-1 items-center justify-end gap-6 text-sm font-medium text-white/70 lg:flex">
                     <a href="#services" class="transition hover:text-white">خدمات</a>
                     <a href="#projects" class="transition hover:text-white">نمونه‌کارها</a>
                     <a href="#process" class="transition hover:text-white">فرایند</a>
                     <a href="#testimonials" class="transition hover:text-white">دیدگاه مشتریان</a>
                     <a href="#contact" class="transition hover:text-white">ارتباط</a>
                 </div>
-                <div class="flex flex-wrap items-center gap-3">
+                <div class="hidden flex-nowrap items-center gap-3 lg:flex">
                     <div class="flex items-center rounded-full border border-white/20 bg-white/5 p-1 text-xs font-semibold">
                         <a href="en.html" class="rounded-full px-3 py-1 transition text-white/70 hover:text-white">EN</a>
                         <a href="fa.html" class="rounded-full px-3 py-1 transition bg-white text-slate-950 shadow">فا</a>
                     </div>
                     <a href="#contact" class="rounded-full bg-gradient-to-r from-brand-500 to-cyan-400 px-5 py-2 text-sm font-semibold text-slate-950 shadow-glow transition hover:-translate-y-0.5 hover:shadow-xl">تماس بگیرید</a>
+                </div>
+                <div id="mobile-menu" class="hidden w-full space-y-4 border-t border-white/10 pt-4 text-right text-sm font-medium text-white/70 lg:hidden">
+                    <div class="flex flex-col gap-3">
+                        <a href="#services" class="transition hover:text-white">خدمات</a>
+                        <a href="#projects" class="transition hover:text-white">نمونه‌کارها</a>
+                        <a href="#process" class="transition hover:text-white">فرایند</a>
+                        <a href="#testimonials" class="transition hover:text-white">دیدگاه مشتریان</a>
+                        <a href="#contact" class="transition hover:text-white">ارتباط</a>
+                    </div>
+                    <div class="h-px bg-white/10"></div>
+                    <div class="flex flex-col gap-3 text-sm font-semibold text-white/80">
+                        <div class="flex justify-end">
+                            <div class="flex items-center rounded-full border border-white/20 bg-white/5 p-1 text-xs">
+                                <a href="en.html" class="rounded-full px-3 py-1 transition text-white/70 hover:text-white">EN</a>
+                                <a href="fa.html" class="rounded-full px-3 py-1 transition bg-white text-slate-950 shadow">فا</a>
+                            </div>
+                        </div>
+                        <a href="#contact" class="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-brand-500 to-cyan-400 px-5 py-2 text-sm text-slate-950 shadow-glow transition hover:-translate-y-0.5 hover:shadow-xl">تماس بگیرید</a>
+                    </div>
                 </div>
             </nav>
         </header>
@@ -116,7 +146,7 @@
                             <a href="#projects" class="rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-xl shadow-brand-500/30 transition hover:-translate-y-0.5 hover:shadow-brand-400/40">مشاهده‌ی نمونه‌کارها</a>
                             <a href="mailto:info@shahindev.com" class="rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white/80 transition hover:border-brand-300/60 hover:text-white">تنظیم جلسه</a>
                         </div>
-                        <div class="grid grid-cols-2 gap-6 pt-8 text-sm text-white/70 sm:grid-cols-4">
+                        <div class="grid grid-cols-1 gap-6 pt-8 text-sm text-white/70 sm:grid-cols-2 lg:grid-cols-4">
                             <div class="text-right">
                                 <p class="text-3xl font-semibold text-white">۸+</p>
                                 <p>سال تجربه در ساخت رابط کاربری</p>
@@ -138,7 +168,7 @@
                 </div>
             </section>
 
-            <section id="services" class="relative border-t border-white/10 bg-slate-950/90 py-24">
+            <section id="services" class="relative scroll-mt-24 border-t border-white/10 bg-slate-950/90 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="mx-auto max-w-3xl space-y-4 text-right">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold text-brand-200 tracking-normal">خدمات</span>
@@ -192,7 +222,7 @@
                 </div>
             </section>
 
-            <section id="projects" class="relative border-t border-white/10 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 py-24">
+            <section id="projects" class="relative scroll-mt-24 border-t border-white/10 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="flex flex-col gap-6 lg:flex-row lg:flex-row-reverse lg:items-end lg:justify-between">
                       <a href="mailto:info@shahindev.com" class="inline-flex flex-row-reverse items-center gap-2 self-end rounded-full border border-white/20 px-5 py-3 text-sm font-semibold text-white/80 transition hover:border-brand-300/60 hover:text-white">
@@ -270,7 +300,7 @@
                 </div>
             </section>
 
-            <section id="process" class="relative border-t border-white/10 bg-slate-950/95 py-24">
+            <section id="process" class="relative scroll-mt-24 border-t border-white/10 bg-slate-950/95 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="mx-auto max-w-3xl space-y-4 text-right">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold text-brand-200 tracking-normal">فرایند</span>
@@ -318,7 +348,7 @@
                     </div>
                 </div>
             </section>
-            <section id="testimonials" class="relative border-t border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-24">
+            <section id="testimonials" class="relative scroll-mt-24 border-t border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-24">
                 <div class="mx-auto max-w-6xl px-6 lg:px-8">
                     <div class="mx-auto max-w-3xl space-y-4 text-right">
                         <span class="inline-block rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold text-brand-200 tracking-normal">دیدگاه مشتریان</span>
@@ -347,7 +377,7 @@
                         </article>
                     </div>
                 </div>
-            </section>            <section id="contact" class="relative border-t border-white/10 bg-slate-950/95 py-24">
+            </section>            <section id="contact" class="relative scroll-mt-24 border-t border-white/10 bg-slate-950/95 py-24">
                 <div class="absolute inset-x-0 -top-20 -z-10 flex justify-center blur-3xl">
                     <div class="h-64 w-[36rem] bg-gradient-to-br from-brand-500/30 via-cyan-400/20 to-emerald-300/20 opacity-70"></div>
                 </div>
@@ -450,6 +480,57 @@
                 </p>
             </div>
         </footer>
+
+        <script>
+            (function () {
+                const button = document.getElementById('mobile-menu-button');
+                const menu = document.getElementById('mobile-menu');
+                if (!button || !menu) return;
+                const icons = {
+                    open: button.querySelector('[data-menu-icon="open"]'),
+                    close: button.querySelector('[data-menu-icon="close"]'),
+                };
+                const setIcons = (isOpen) => {
+                    if (!icons.open || !icons.close) return;
+                    if (isOpen) {
+                        icons.open.classList.add('hidden');
+                        icons.close.classList.remove('hidden');
+                    } else {
+                        icons.open.classList.remove('hidden');
+                        icons.close.classList.add('hidden');
+                    }
+                };
+                const toggle = () => {
+                    const isOpen = button.getAttribute('aria-expanded') === 'true';
+                    const nextState = !isOpen;
+                    button.setAttribute('aria-expanded', String(nextState));
+                    menu.classList.toggle('hidden', !nextState);
+                    setIcons(nextState);
+                };
+                setIcons(false);
+                button.addEventListener('click', toggle);
+                menu.querySelectorAll('a').forEach((link) => {
+                    link.addEventListener('click', () => {
+                        if (button.getAttribute('aria-expanded') === 'true') {
+                            toggle();
+                        }
+                    });
+                });
+                const mediaQuery = window.matchMedia('(min-width: 1024px)');
+                const handleChange = (event) => {
+                    if (event.matches) {
+                        button.setAttribute('aria-expanded', 'false');
+                        menu.classList.add('hidden');
+                        setIcons(false);
+                    }
+                };
+                if (mediaQuery.addEventListener) {
+                    mediaQuery.addEventListener('change', handleChange);
+                } else if (mediaQuery.addListener) {
+                    mediaQuery.addListener(handleChange);
+                }
+            })();
+        </script>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a mobile navigation toggle and menu panel to the Farsi and English pages
- update hero statistics grids to stack on small screens and add scroll offsets for anchor sections
- include a shared script that manages menu state, icon swapping, and resets when the viewport widens

## Testing
- Not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d792384de4832db899ccb2634f6f24